### PR TITLE
add SendMediaGroup support

### DIFF
--- a/main.js
+++ b/main.js
@@ -321,11 +321,9 @@ function saveSendRequest(msg) {
 
 function _sendMessageHelper(dest, name, text, options) {
     let count = 0;
-
     if (options && options.chatId !== undefined && options.user === undefined) {
         options.user = users[options.chatId];
     }
-
     if (options && options.latitude !== undefined) {
         adapter.log.debug('Send location to "' + name + '": ' + text);
         if (bot) {
@@ -345,7 +343,66 @@ function _sendMessageHelper(dest, name, text, options) {
                     options = null;
                 });
         }
-    } else if (actions.indexOf(text) !== -1) {
+    }
+    else if(options && options.type=== 'mediagroup')
+    {
+      adapter.log.debug('Send mediagroup to "' + name + '": ');
+      if(bot)
+      {
+        const {media:fileNames} = options;
+        if(fileNames instanceof Array)
+        {
+          bot.sendChatAction(dest, 'upload_photo')
+            .then((res) => {
+          if(fileNames.every((name) => fs.existsSync(name)))
+          {
+              const filesAsArray = fileNames
+                                  .map((element) =>{
+                                      try{
+                                        return {type: "photo",media: fs.readFileSync(element)}
+                                        }
+                                      catch(error){
+                                            adapter.log.error('Cannot read file' + element);
+                                          return undefined;
+                                      }
+                                    })
+                                  .filter((element) => element != undefined);
+              const size = filesAsArray.map((element)=>element.media.length).reduce((acc,val)=>acc+val);
+              adapter.log.info('Send mediagroup to "' + name + '": ' + size + ' bytes');
+              if(filesAsArray.length >0){
+                bot.sendMediaGroup(dest,filesAsArray).
+                  then((response) => saveSendRequest(response)).
+                  then(()=>{
+                    adapter.log.debug('photos sent');
+                    options = null;
+                    count++;
+                  }).catch(error => {
+                      if (options.chatId) {
+                          adapter.log.error('Cannot send mediagroup [chatId - ' + options.chatId + ']: ' + error);
+                      } else {
+                          adapter.log.error('Cannot send mediagroup [user - ' + options.user + ']: ' + error);
+                      }
+                      options = null;
+                  });
+                }
+            }
+            else
+            {
+              adapter.log.debug('files must exists');
+              options = null;
+            }
+          });
+        }
+        else
+            adapter.log.debug('option media should be an array');
+      }
+      else
+      {
+        adapter.log.debug('no files added!');
+        options = null;
+      }
+    }
+    else if (text && typeof text === 'string' && actions.includes(text)) {
         adapter.log.debug('Send action to "' + name + '": ' + text);
         if (bot) {
             bot.sendChatAction(dest, text)
@@ -364,7 +421,9 @@ function _sendMessageHelper(dest, name, text, options) {
                     options = null;
                 });
         }
-    } else if (text && ((typeof text === 'string' && text.match(/\.webp$/i) && fs.existsSync(text)) || (options && options.type === 'sticker'))) {
+    }
+    else if (text && ((typeof text === 'string' && text.match(/\.webp$/i) && fs.existsSync(text)) || (options && options.type === 'sticker')))
+    {
         if (typeof text === 'string') {
             adapter.log.debug('Send sticker to "' + name + '": ' + text);
         } else {
@@ -387,7 +446,30 @@ function _sendMessageHelper(dest, name, text, options) {
                     options = null;
                 });
         }
-    } else if (text && ((typeof text === 'string' && text.match(/\.(mp4|gif)$/i) && fs.existsSync(text)) || (options && options.type === 'video'))) {
+    } else if (text && ((typeof text === 'string' && text.match(/\.(gif)/i) && fs.existsSync(text)) || (options && options.type === 'animation'))){
+      if (typeof text === 'string') {
+          adapter.log.debug('Send animation to "' + name + '": ' + text);
+      } else {
+          adapter.log.debug('Send animation to "' + name + '": ' + text.length + ' bytes');
+      }
+      if (bot) {
+          bot.sendAnimation(dest, text, options)
+              .then(response => saveSendRequest(response))
+              .then(() => {
+                  adapter.log.debug('animation sent');
+                  options = null;
+                  count++;
+              })
+              .catch(error => {
+                  if (options.chatId) {
+                      adapter.log.error('Cannot send animation [chatId - ' + options.chatId + ']: ' + error);
+                  } else {
+                      adapter.log.error('Cannot send animation [user - ' + options.user + ']: ' + error);
+                  }
+                  options = null;
+              });
+    }
+    } else if (text && ((typeof text === 'string' && text.match(/\.(mp4)$/i) && fs.existsSync(text)) || (options && options.type === 'video'))) {
         if (typeof text === 'string') {
             adapter.log.debug('Send video to "' + name + '": ' + text);
         } else {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "message"
   ],
   "dependencies": {
-    "node-telegram-bot-api": "^0.30.0",
-    "socksv5": "https://github.com/christophgysin/socksv5/tarball/7b4eba5b30ecdb6d9e656dcfede1e6884dc7c6d9",
-    "@iobroker/adapter-core": "^1.0.3"
+    "@iobroker/adapter-core": "^1.0.3",
+    "node-telegram-bot-api": "git+https://github.com/yagop/node-telegram-bot-api.git#master",
+    "socksv5": "https://github.com/christophgysin/socksv5/tarball/7b4eba5b30ecdb6d9e656dcfede1e6884dc7c6d9"
   },
   "devDependencies": {
     "gulp": "^4.0.0",


### PR DESCRIPTION
#29 add sendmediagroup
usage:
`const fileNames =["/opt/gif/1.jpg","/opt/gif/2.jpg","/opt/gif/3.jpg"];

  sendTo('telegram.0', {
      chatId : getState('telegram.0.communicate.requestChatId'/*User ID of last received request*/).val,
      media: fileNames,
      type: 'mediagroup'
  });`

#gif sending gif as sendanimation()
in some situations the animation stopped if the gif was sent with sendphoho or senddocument