### PR TITLE
Allow JSON objects in telegram.*.communicate.response

### DIFF
--- a/main.js
+++ b/main.js
@@ -670,6 +670,11 @@ function sendMessage(text, user, chatId, options) {
         return adapter.log.warn('Invalid text: null');
     }
 
+    if (typeof text === 'object' && text.text !== undefined && typeof text.text === 'string' && options === undefined) {
+        options = text;
+        text = options.text;
+    }
+
     if (options) {
         if (options.chatId !== undefined) delete options.chatId;
         if (options.text   !== undefined) delete options.text;


### PR DESCRIPTION
This change makes it possible to send markup / HTML encoded
messages e.g. from node-red by storing a JSON structure
into the telegram.*.communicate.response.

Example:

```
msg.payload = {
    text: 'This is a *bold* text',
    parse_mode: 'Markdown'
}
```