### PR TITLE
Fixing error with keyboard.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1166,7 +1166,7 @@ function getCommandsKeyboard(chatId) {
                 adapter.log.warn(`Unsupported state type for keyboard: ${commands[id].type}. Only numbers and booleans are supported`);
             }
         } else {
-            keyboard.push(`${commands[id].alias} ?`);
+            keyboard.push([`${commands[id].alias} ?`]);
         }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.telegram",
   "description": "The adapter allows to send and receive telegram messages from ioBroker and to be a broker.",
-  "version": "1.6.2",
+  "version": "1.6.1",
   "author": "bluefox <dogafox@gmail.com>",
   "homepage": "https://github.com/iobroker-community-adapters/ioBroker.telegram",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.telegram",
   "description": "The adapter allows to send and receive telegram messages from ioBroker and to be a broker.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "bluefox <dogafox@gmail.com>",
   "homepage": "https://github.com/iobroker-community-adapters/ioBroker.telegram",
   "repository": {


### PR DESCRIPTION
I have discovered, that if you have readonly values, you get this error: 

> Error: ETELEGRAM: 400 Bad Request: field "keyboard" of the ReplyKeyboardMarkup must be an Array of Arrays