### PR TITLE
Add possibility to process in scripts the RAW data send by bot via botSendRaw

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -308,6 +308,18 @@
             "native": {}
         },
         {
+            "_id": "communicate.botSendRaw",
+            "type": "state",
+            "common": {
+                "role": "json",
+                "name": "Raw Data of last sent message by the bot",
+                "type": "string",
+                "read": true,
+                "write": false
+            },
+            "native": {}
+        },
+        {
             "_id": "communicate.requestUserId",
             "type": "state",
             "common": {

--- a/main.js
+++ b/main.js
@@ -444,6 +444,11 @@ function handleWebHook(req, res) {
 function saveSendRequest(msg) {
     adapter.log.debug('Request: ' + JSON.stringify(msg));
 
+    if (msg && adapter.config.storeRawRequest) {
+        adapter.setState('communicate.botSendRaw', JSON.stringify(msg), true, err =>
+            err && adapter.log.error(err));
+    }
+
     if (msg && msg.message_id) {
         adapter.setState('communicate.botSendMessageId', msg.message_id, true, err =>
             err && adapter.log.error(err));


### PR DESCRIPTION
It can be useful, when in the same time you need to process messageID, chatID and user.
Currently `botSendMessageId` and `botSendChatId` states updated in series, and to
process it in one callback it required some specific in coding.
In case of `botSendRaw` state you can process it more clear way.
I used the same config parameter, as for requestRaw enablement, to not overload
the adapter by config params.

Changes to be committed:
	modified:   io-package.json
	modified:   main.js