### PR TITLE
Don't send message on object change

### DIFF
--- a/main.js
+++ b/main.js
@@ -351,6 +351,12 @@ function startAdapter(options) {
             commands[id].min    = obj.common && obj.common.min;
             commands[id].max    = obj.common && obj.common.max;
             commands[id].alias  = alias;
+             // read actual state to detect changes
+            if (commands[id].reportChanges) {
+                adapter.getForeignStateAsync(id).then(state => {
+                    commands[id].lastState = state ? state.val : undefined;
+                });
+            }
         } else if (commands[id]) {
             adapter.log.debug(`Removed command: ${id}`);
             delete commands[id];


### PR DESCRIPTION
This is a follow-up to eada2fcac9dbe452fd1ea03c90dacdc684846c69 (#190). Even with "Report changes only" checked, there used to be a message whenever the object had changed. That's because the `lastState` vanished and the next state update would be considered a change.

Fixed by reading the current value similar to how it's done in `readAllNames()`.

As a (positive?) side-effect, there are also no messages anymore when the monitoring is initially enabled or settings (like on/off text) are changed.