### PR TITLE
feat: add option for silent state updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Use telegram service to communicate with ioBroker
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+* (theknut) add option to send state updates without notification sound [#793]
+
 ### 3.0.1 (2023-12-08)
 * (foxriver76) send the actual message too via notification-manager
 

--- a/admin/jsonCustom.json
+++ b/admin/jsonCustom.json
@@ -74,6 +74,32 @@
       "uk": "Повідомляти тільки про зміни",
       "zh-cn": "仅报告更改"
     },
+    "Silent": {
+      "en": "Silent",
+      "de": "Silent",
+      "ru": "Молчание",
+      "pt": "Silencioso",
+      "nl": "Stil",
+      "fr": "Silencieux",
+      "it": "Silente",
+      "es": "Silent",
+      "pl": "Cichy",
+      "uk": "Сидіння",
+      "zh-cn": "安静"
+    },
+    "Send without notification sound": {
+      "en": "Send without notification sound",
+      "de": "Senden ohne Benachrichtigungston",
+      "ru": "Отправить без уведомления",
+      "pt": "Enviar sem aviso de som",
+      "nl": "Verzend zonder meldingsgeluid",
+      "fr": "Envoyer sans notification sonore",
+      "it": "Invia senza registrazione suono",
+      "es": "Enviar sin notificación de sonido",
+      "pl": "Wyślij dźwięk bez powiadomienia",
+      "uk": "Відправити повідомлення",
+      "zh-cn": "无通知声音发送"
+    },
     "Sends a new message if the value changes": {
       "en": "Sends a new message if the value changes",
       "de": "Sendet eine neue Nachricht, wenn sich der Wert ändert",
@@ -269,14 +295,21 @@
       "label": "Report updates",
       "help": "Sends a new message if the value updates",
       "defaultFunc": "customObj.common && customObj.common.read !== false",
-      "sm": 6
+      "sm": 5
     },
     "reportChanges": {
       "type": "checkbox",
       "label": "Report changes only",
       "help": "Sends a new message if the value changes",
       "hidden": "data.report !== true",
-      "sm": 6
+      "sm": 4
+    },
+    "reportSilent": {
+      "type": "checkbox",
+      "label": "Silent",
+      "help": "Send without notification sound",
+      "hidden": "data.report !== true",
+      "sm": 3
     },
     "buttons": {
       "newLine": true,

--- a/main.js
+++ b/main.js
@@ -323,13 +323,14 @@ function startAdapter(options) {
                 }
             } else {
                 if (commands[id] && commands[id].report) {
+                    const options = commands[id].reportSilent == true ? {disable_notification: true} : { };
                     if (commands[id].reportChanges) {
                         if (state.val !== commands[id].lastState) {
                             commands[id].lastState = state.val;
-                            sendMessage(getStatus(id, state));
+                            sendMessage(getStatus(id, state), null, null, options);
                         }
                     } else {
-                        sendMessage(getStatus(id, state));
+                        sendMessage(getStatus(id, state), null, null, options);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #793

New option to send state updates without notification sound.

![image](https://github.com/iobroker-community-adapters/ioBroker.telegram/assets/6503243/8fb9659a-df06-4787-9382-737e82f8b70e)