### PR TITLE
Improve response on anything sent to Telegram.

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 /* jslint node: true */
 'use strict';
 
-// https://github.com/yagop/node-telegram-bot-api/issues/319 (because of bluebird)
+// https://github.com/yagop/node-telegram-bot-api/issues/319 (because of bluebird) 
 process.env.NTBA_FIX_319 = 1;
 
 const TelegramBot = require('node-telegram-bot-api');

--- a/main.js
+++ b/main.js
@@ -797,6 +797,8 @@ function executeSending(action, options, resolve){
             // log error to the system
             adapter.log.error(`Failed sending [${options.chatId ? 'chatId' : 'user'} - ${options.chatId ? options.chatId : options.user}]: ${error}`);
             options = null;
+            // add the error to the message ids object
+            messageIds.error = {[options.chat_id ? options.chat_id : options.chatId] : error};
             // send the succesfully send messages as callback
             resolve(JSON.stringify(messageIds));
         });
@@ -2025,7 +2027,7 @@ function buildMessageFromNotification(message) {
     const readableInstances = Object.entries(instances).map(([instance, entry]) => `${instance.substring('system.adapter.'.length)}: ${getNewestMessage(entry.messages)}`);
 
     const text = `${message.category.description}
-${message.host}:   
+${message.host}:
 ${readableInstances.join('\n')}
     `;
 


### PR DESCRIPTION
- in the same response object (`messageId`) the current error is added ad separate property `error`, which is another object where property `chat_id` consists exact error.
It has no break current returned data.
Short explanation:
- current return structure:
```
[
  {
    chatId1: messageId1
  },
  ...
]
```
- proposed return structure:
```
[
  {
    chatId1: messageId1
  },
  ...
  {
   chatId9: messageId9
   "error": {
     chatId9: "error details"
   }
  }
]
```