### PR TITLE
Test and Release action node 16.x elimination.

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           install-command: 'npm install'
           lint: true
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: ioBroker/testing-action-deploy@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           install-command: 'npm install'
           npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Die to ioBroker.js-controller in latest version doesn't support node 16.x, proposed to eliminate it from Test and Release action.
Otherwise all tests with this version of node will fail.