### PR TITLE
Make a license information in `io-package.json` comply with `check_and_lint` action.

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -181,7 +181,6 @@
       "apollon77 <iobroker@fischer-ka.de>",
       "Matthias Kleine <info@haus-automatisierung.com>"
     ],
-    "license": "MIT",
     "platform": "Javascript/Node.js",
     "mode": "daemon",
     "messagebox": true,
@@ -240,6 +239,7 @@
       "name": "ActionTelegram"
     },
     "licenseInformation": {
+      "license": "MIT",
       "type": "free",
       "link": "https://github.com/iobroker-community-adapters/ioBroker.telegram/blob/master/LICENSE"
     }


### PR DESCRIPTION
Currently there is an error in `check_and_lint`:
```
 Validate the package files
       Check contents of io-package.json
         common.license should not exist together with common.licenseInformation:
```
To fix it
```
    "license": "MIT",
```
moved from common section to common.licenseInformation:
```
    "licenseInformation": {
      "license": "MIT",
```