### PR TITLE
fix: handle Telegram live location updates

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2824,6 +2824,18 @@ class Telegram extends Adapter {
                 }
             });
 
+            // Telegram Live Location updates are delivered as edited_message events.
+            // Process them like normal messages so location and raw request states are updated.
+            bot.on('edited_message', msg => {
+                this.connectionState(true);
+
+                if (this.config.storeRawRequest) {
+                    this.setStateSafe('communicate.requestRaw', { val: JSON.stringify(msg, null, 2), ack: true });
+                }
+
+                this.getMessage(msg);
+            });
+
             // Channel posts (in a channel where the bot is an admin) are delivered as a separate event, not
             // as `message`, so they were ignored before. They are anonymous (no `msg.from`), therefore the
             // auth/command pipeline cannot run; instead expose the post text and metadata so scripts can


### PR DESCRIPTION
Description

Telegram Live Location updates are delivered as "edited_message" events rather than regular "message" events.

The Telegram adapter currently handles "message" events and therefore does not process subsequent Live Location updates. As a result, "communicate.requestLocation" and, when enabled, "communicate.requestRaw" are not updated while a Live Location is active.

This change adds an "edited_message" handler and processes the update through the existing "getMessage()" logic.

Result

Live Location updates now correctly update:

- "communicate.requestLocation"
- "communicate.requestRaw" (when "storeRawRequest" is enabled)

The existing location handling in "getMessage()" is reused, so no duplicate location-processing logic is required.

Testing

- "npm run check" ✅
- "npm run lint" ✅
- "npm run build:ts" ✅
- Tested with a real Telegram Live Location: coordinates were received and updated periodically in ioBroker.